### PR TITLE
Disable PyUp bot

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,3 @@
 ---
 
-update: insecure
-schedule: "every day"
+update: False


### PR DESCRIPTION
We are already getting security updates from Dependabot. There is no need to get each PR twice.