### PR TITLE
Drop last remnants of nose

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Removed
 -------
 
 * Python 3.6 is no longer supported.
+* Dropped support for running tests via `setup.py test`.
+  The mechanism is considered deprecated by upstream and removing it allows us to drop a dependency.
+
 
 
 Version 0.3.0 - 2021-02-05

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,8 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=requirements,
     setup_requires=[
-        'nose',
         'setuptools_scm',
     ],
-    tests_require=[
-        'coverage',
-        'mock',
-        'devpi-plumber[test]',
-    ],
-    test_suite='nose.collector',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
When switching von pytest to nose we had accidentally left in the requirements enabling to use nose via `setup.py test`. As the `setup.py test` is deprecated anyhow, we drop those without replacement.