### PR TITLE
Update tested dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --strip-extras
 #
-anyio==4.8.0
+anyio==4.9.0
     # via httpx
 argon2-cffi==23.1.0
     # via
@@ -12,7 +12,7 @@ argon2-cffi==23.1.0
     #   passlib
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-attrs==25.1.0
+attrs==25.3.0
     # via devpi-server
 build==1.2.2.post1
     # via
@@ -29,7 +29,7 @@ charset-normalizer==3.4.1
     # via requests
 check-manifest==0.50
     # via devpi-client
-coverage==7.6.12
+coverage==7.8.0
     # via pytest-cov
 defusedxml==0.7.1
     # via devpi-server
@@ -51,9 +51,9 @@ exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via devpi-server
@@ -65,8 +65,10 @@ idna==3.10
     #   httpx
     #   requests
 importlib-metadata==8.6.1
-    # via build
-iniconfig==2.0.0
+    # via
+    #   build
+    #   setuptools-scm
+iniconfig==2.1.0
     # via
     #   devpi-client
     #   pytest
@@ -78,7 +80,7 @@ lazy==1.6
     #   devpi-server
 mock==5.2.0
     # via -r requirements.in
-packaging==24.2
+packaging==25.0
     # via
     #   build
     #   packaging-legacy
@@ -98,7 +100,7 @@ plaster==1.1.2
     #   pyramid
 plaster-pastedeploy==1.0.1
     # via pyramid
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   devpi-client
     #   devpi-server
@@ -121,7 +123,7 @@ pytest==8.3.5
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via strictyaml
@@ -137,7 +139,7 @@ ruamel-yaml==0.18.10
     # via devpi-server
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-setuptools-scm==8.2.0
+setuptools-scm==8.3.1
     # via -r requirements.in
 six==1.17.0
     # via
@@ -163,12 +165,12 @@ twitter-common-dirutil==0.3.11
     # via twitter-common-contextutil
 twitter-common-lang==0.3.11
     # via twitter-common-dirutil
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   anyio
     #   python-utils
     #   setuptools-scm
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
 venusian==3.1.1
     # via pyramid


### PR DESCRIPTION
Verify that things also work when using a version of h11 not affected by CVE-2025-43859.